### PR TITLE
修复错误处理-主要针对返回前端时处理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *swp
 .idea
+

--- a/auth/admin.go
+++ b/auth/admin.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"errors"
 	"github.com/fanux/fist/tools"
 )
 
@@ -55,14 +54,14 @@ func (*Admin) LoadSecret() error {
 
 func (admin *Admin) IsAdmin() (bool, error) {
 	if admin.Name == "" {
-		return false, errors.New("the username is empty")
+		return false, tools.ErrUserNameEmpty
 	}
 	if admin.Passwd == "" {
-		return false, errors.New("the password is empty")
+		return false, tools.ErrPasswordEmpty
 	}
 	if admin.Name == AdminUsername && admin.Passwd == AdminPassword {
 		return true, nil
 	} else {
-		return false, errors.New("the username and password is mismatching")
+		return false, tools.ErrValidateUserPassword
 	}
 }

--- a/auth/server.go
+++ b/auth/server.go
@@ -85,6 +85,7 @@ func handlerToken(request *restful.Request, response *restful.Response) {
 	signingAlg, err := signatureAlgorithm(&Priv)
 	if err != nil {
 		fmt.Println("failed to sign payload", err)
+		tools.ResponseError(response, tools.ErrSignPayload)
 		return
 	}
 
@@ -105,12 +106,14 @@ func handlerToken(request *restful.Request, response *restful.Response) {
 	fmt.Printf("token claims: %s", payload)
 	if err != nil {
 		fmt.Println("could not serialize claims", err)
+		tools.ResponseError(response, tools.ErrSerializeClaims)
 		return
 	}
 
 	var idToken string
 	if idToken, err = signPayload(&Priv, signingAlg, payload); err != nil {
 		fmt.Println("failed to sign payload", err)
+		tools.ResponseError(response, tools.ErrSignPayload)
 		return
 	}
 

--- a/auth/server.go
+++ b/auth/server.go
@@ -84,8 +84,7 @@ func handlerToken(request *restful.Request, response *restful.Response) {
 
 	signingAlg, err := signatureAlgorithm(&Priv)
 	if err != nil {
-		fmt.Println("failed to sign payload", err)
-		tools.ResponseError(response, tools.ErrSignPayload)
+		tools.ResponseSystemError(response, err)
 		return
 	}
 
@@ -105,15 +104,13 @@ func handlerToken(request *restful.Request, response *restful.Response) {
 	payload, err := json.Marshal(&tok)
 	fmt.Printf("token claims: %s", payload)
 	if err != nil {
-		fmt.Println("could not serialize claims", err)
-		tools.ResponseError(response, tools.ErrSerializeClaims)
+		tools.ResponseSystemError(response, err)
 		return
 	}
 
 	var idToken string
 	if idToken, err = signPayload(&Priv, signingAlg, payload); err != nil {
-		fmt.Println("failed to sign payload", err)
-		tools.ResponseError(response, tools.ErrSignPayload)
+		tools.ResponseSystemError(response, err)
 		return
 	}
 

--- a/terminal/server.go
+++ b/terminal/server.go
@@ -1,12 +1,11 @@
 package terminal
 
 import (
-	"errors"
 	"github.com/fanux/fist/tools"
 	"log"
 	"net/http"
 
-	restful "github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful"
 )
 
 //Register is
@@ -48,7 +47,7 @@ func handleHeartbeat(request *restful.Request, response *restful.Response) {
 	}
 	tid := request.QueryParameter("tid")
 	if tid == "" {
-		tools.ResponseError(response, errors.New("the param tid is empty"))
+		tools.ResponseError(response, tools.ErrParamTidEmpty)
 		return
 	}
 	namespace := request.QueryParameter("namespace")

--- a/terminal/server.go
+++ b/terminal/server.go
@@ -26,13 +26,13 @@ func createTerminal(request *restful.Request, response *restful.Response) {
 	t := newTerminal()
 	err := request.ReadEntity(t)
 	if err != nil {
-		tools.ResponseError(response, err)
+		tools.ResponseSystemError(response, err)
 		return
 	}
 
 	err = t.Create()
 	if err != nil {
-		tools.ResponseError(response, err)
+		tools.ResponseSystemError(response, err)
 		return
 	}
 	tools.ResponseSuccess(response, t)
@@ -42,12 +42,12 @@ func handleHeartbeat(request *restful.Request, response *restful.Response) {
 	//get client of k8s
 	clientset, err := tools.GetK8sClient()
 	if err != nil {
-		tools.ResponseError(response, err)
+		tools.ResponseSystemError(response, err)
 		return
 	}
 	tid := request.QueryParameter("tid")
 	if tid == "" {
-		tools.ResponseError(response, tools.ErrParamTidEmpty)
+		tools.ResponseSystemError(response, tools.ErrParamTidEmpty)
 		return
 	}
 	namespace := request.QueryParameter("namespace")
@@ -58,7 +58,7 @@ func handleHeartbeat(request *restful.Request, response *restful.Response) {
 	hbInterface = NewHeartbeater(tid, namespace)
 	err = hbInterface.UpdateTimestamp(clientset)
 	if err != nil {
-		tools.ResponseError(response, err)
+		tools.ResponseSystemError(response, err)
 		return
 	}
 	tools.ResponseSuccess(response, nil)

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -1,7 +1,6 @@
 package terminal
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -179,11 +178,11 @@ func withoutToken(t *Terminal, clientset *kubernetes.Clientset) error {
 			}
 			token := string(saTokenSecrets.Data["token"])
 			if err != nil {
-				return errors.New("the serviceAccount token is empty")
+				return tools.ErrServiceAccountEmpty
 			}
 			t.UserToken = token
 		} else {
-			return errors.New("the serviceAccount token is not exists")
+			return tools.ErrServiceAccountNotExists
 		}
 	}
 	return nil

--- a/tools/errors.go
+++ b/tools/errors.go
@@ -1,0 +1,17 @@
+package tools
+
+import (
+	"errors"
+)
+
+var (
+	ErrUserNameEmpty           = errors.New("the username is empty")
+	ErrPasswordEmpty           = errors.New("the password is empty")
+	ErrValidateUserPassword    = errors.New("the username and password is mismatching")
+	ErrServiceAccountEmpty     = errors.New("the serviceAccount token is empty")
+	ErrServiceAccountNotExists = errors.New("the serviceAccount token is not exists")
+	ErrParamTidEmpty           = errors.New("the param tid is empty")
+
+	ErrSignPayload     = errors.New("failed to sign payload")
+	ErrSerializeClaims = errors.New("could not serialize claims")
+)

--- a/tools/errors.go
+++ b/tools/errors.go
@@ -4,6 +4,10 @@ import (
 	"errors"
 )
 
+const (
+	ErrMessageSystem = "system error"
+)
+
 var (
 	ErrUserNameEmpty           = errors.New("the username is empty")
 	ErrPasswordEmpty           = errors.New("the password is empty")

--- a/tools/response.go
+++ b/tools/response.go
@@ -1,6 +1,9 @@
 package tools
 
-import "github.com/emicklei/go-restful"
+import (
+	"fmt"
+	"github.com/emicklei/go-restful"
+)
 
 type responseObject struct {
 	Message string      `json:"message"`
@@ -14,10 +17,21 @@ func ResponseSuccess(response *restful.Response, data interface{}) {
 }
 
 //ResponseError
-func ResponseErrorAndCode(response *restful.Response, code int32, err error) {
-	response.WriteEntity(responseObject{Code: code, Message: err.Error(), Data: ""})
+func ResponseErrorAndCodeMessage(response *restful.Response, code int32, err error, message string) {
+	fmt.Printf("response error: %v", err)
+	response.WriteEntity(responseObject{Code: code, Message: message, Data: ""})
 }
 
+//custom error
 func ResponseError(response *restful.Response, err error) {
-	ResponseErrorAndCode(response, 500, err)
+	ResponseErrorAndCodeMessage(response, 500, err, err.Error())
+}
+
+func ResponseSystemError(response *restful.Response, err error) {
+	ResponseErrorAndCodeMessage(response, 500, err, ErrMessageSystem)
+}
+
+//system error and error msg
+func ResponseErrorAndMessage(response *restful.Response, err error, message string) {
+	ResponseErrorAndCodeMessage(response, 500, err, message)
 }


### PR DESCRIPTION
主要修复自定义错误类型和返回实体时错误信息的定义
所有自定义错误类型 均定义在tools/error.go ,包括错误信息。

返回实体与前端对接时需要统一格式。

返回实体若有错误信息默认控制台打印错误

ResponseError   //返回自定义错误类型
ResponseSystemError //返回系统错误类型
ResponseErrorAndMessage // 返回错误和消息体提示信息